### PR TITLE
fix: current version

### DIFF
--- a/npm-bump
+++ b/npm-bump
@@ -118,7 +118,7 @@ function get_newest_versions() {
 }
 
 function install_version() {
-    current_version=$(npm list --depth=0 | grep "$1@" | grep -E -o "@.*$" | sed "s/@//")
+    current_version=$(npm list --depth=0 | grep " $1@" | grep -E -o "@.*$" | sed "s/@//")
     echo "Try to bump $1 from $current_version to $2"
 
     if [ -n "${command}" ]; then


### PR DESCRIPTION
# Reproduction : 

```
 npm list --depth=0 | grep "prettier@"
├── ember-template-lint-plugin-prettier@4.0.0
├── eslint-config-prettier@8.5.0
├── eslint-plugin-prettier@4.2.1
├── prettier@2.7.1
```

Alors qu'on souhaite uniquement prettier.
Pour ça on ajoute un espace avant le nom de la librairie. 